### PR TITLE
Stop instances of DOM Node being wrapped as it throws a TypeError

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -65,10 +65,14 @@ export function observable (obj) {
   )
 }
 
+function isDomNode (obj) {
+  return Node && obj instanceof Node
+}
+
 function instrumentObservable (obj) {
   const instrument = instrumentations.get(Object.getPrototypeOf(obj))
   // these objects break, when they are wrapped with proxies
-  if (instrument === false) {
+  if (instrument === false || isDomNode(obj)) {
     return obj
   }
   // these objects can be wrapped by Proxies, but require special instrumentation beforehand

--- a/src/observer.js
+++ b/src/observer.js
@@ -66,7 +66,7 @@ export function observable (obj) {
 }
 
 function isDomNode (obj) {
-  return Node && obj instanceof Node
+  return typeof Node === 'function' && obj instanceof Node
 }
 
 function instrumentObservable (obj) {

--- a/tests/observe.test.js
+++ b/tests/observe.test.js
@@ -328,4 +328,16 @@ describe('observe', () => {
     await nextTick()
     expect(dummy).to.equal('p2p1p3')
   })
+
+  it('should not error when a DOM element is added', async () => {
+    let dummy = null
+    const observed = observable({ obj: null })
+    observe(() => (dummy = observed.obj && observed.obj.nodeType))
+
+    await nextTick()
+    expect(dummy).to.equal(null)
+    observed.obj = document
+    await nextTick()
+    expect(dummy).to.equal(9)
+  })
 })


### PR DESCRIPTION
Stop instances of DOM Node being wrapped as it throws a TypeError when accessing it via Reflect.get