### PR TITLE
Allow using objects as key (in Maps, Sets, ...)

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -3,7 +3,7 @@ const ITERATION_KEY = Symbol('iteration key')
 
 export function storeObservable (obj) {
   // this will be used to save (obj.key -> reaction) connections later
-  connectionStore.set(obj, Object.create(null))
+  connectionStore.set(obj, new Map())
 }
 
 export function registerReactionForOperation (reaction, { target, key, type }) {
@@ -12,9 +12,10 @@ export function registerReactionForOperation (reaction, { target, key, type }) {
   }
 
   const reactionsForObj = connectionStore.get(target)
-  let reactionsForKey = reactionsForObj[key]
+  let reactionsForKey = reactionsForObj.get(key)
   if (!reactionsForKey) {
-    reactionsForObj[key] = reactionsForKey = new Set()
+    reactionsForKey = new Set()
+    reactionsForObj.set(key, reactionsForKey)
   }
   // save the fact that the key is used by the reaction during its current run
   if (!reactionsForKey.has(reaction)) {
@@ -28,9 +29,9 @@ export function getReactionsForOperation ({ target, key, type }) {
   const reactionsForKey = new Set()
 
   if (type === 'clear') {
-    for (let key in reactionsForTarget) {
+    reactionsForTarget.forEach((_, key) => {
       addReactionsForKey(reactionsForKey, reactionsForTarget, key)
-    }
+    })
   } else {
     addReactionsForKey(reactionsForKey, reactionsForTarget, key)
   }
@@ -44,7 +45,7 @@ export function getReactionsForOperation ({ target, key, type }) {
 }
 
 function addReactionsForKey (reactionsForKey, reactionsForTarget, key) {
-  const reactions = reactionsForTarget[key]
+  const reactions = reactionsForTarget.get(key)
   reactions && reactions.forEach(reactionsForKey.add, reactionsForKey)
 }
 

--- a/tests/builtIns/Map.test.js
+++ b/tests/builtIns/Map.test.js
@@ -268,4 +268,23 @@ describe('Map', () => {
     raw(map).set('key', 'value')
     expect(dummy).to.equal(0)
   })
+
+  it('should support objects as key', () => {
+    let dummy
+    const key = {}
+    const map = observable(new Map())
+    const mapSpy = spy(() => (dummy = map.get(key)))
+    observe(mapSpy)
+
+    expect(dummy).to.equal(undefined)
+    expect(mapSpy.callCount).to.equal(1)
+
+    map.set(key, 1)
+    expect(dummy).to.equal(1)
+    expect(mapSpy.callCount).to.equal(2)
+
+    map.set({}, 2)
+    expect(dummy).to.equal(1)
+    expect(mapSpy.callCount).to.equal(2)
+  })
 })

--- a/tests/builtIns/Set.test.js
+++ b/tests/builtIns/Set.test.js
@@ -256,4 +256,23 @@ describe('Set', () => {
     raw(set).add('value')
     expect(dummy).to.equal(0)
   })
+
+  it('should support objects as key', () => {
+    let dummy
+    const key = {}
+    const set = observable(new Set())
+    const setSpy = spy(() => (dummy = set.has(key)))
+    observe(setSpy)
+
+    expect(dummy).to.equal(false)
+    expect(setSpy.callCount).to.equal(1)
+
+    set.add({})
+    expect(dummy).to.equal(false)
+    expect(setSpy.callCount).to.equal(1)
+
+    set.add(key)
+    expect(dummy).to.equal(true)
+    expect(setSpy.callCount).to.equal(2)
+  })
 })


### PR DESCRIPTION
Currently, keys are always used as string, since they are stored as property name of an object. This PR allows using objects as key by using a `Map` instead of an object for the storage.

I hope it makes sense. Great project!