### PR TITLE
Fall back to window as globalObj if a CSP is in place.

### DIFF
--- a/src/builtIns/index.js
+++ b/src/builtIns/index.js
@@ -1,7 +1,7 @@
 import collectionHandlers from './collections'
 
 // eslint-disable-next-line
-const globalObj = Function("return this")();
+const globalObj = typeof window === 'object' ? window : Function('return this')();
 
 // built-in object can not be wrapped by Proxies
 // their methods expect the object instance as the 'this' instead of the Proxy wrapper


### PR DESCRIPTION
`Function("return this")()` throws an exception if eval is disabled via a content security policy. This means that this module could not be used in places where it is, such as chrome extension or on the Twitch platform - instead it broke the whole application.

![image](https://user-images.githubusercontent.com/7847742/52306361-03fa1680-2998-11e9-94dd-36aceb946ea3.png)

This should fix this problem, and fall back to the `window` variable in those places, which should cover all common browsers. 