### PR TITLE
fix error "accessing the caller property of a function" on IE11

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -9,7 +9,13 @@ import {
 const hasOwnProperty = Object.prototype.hasOwnProperty
 const wellKnownSymbols = new Set(
   Object.getOwnPropertyNames(Symbol)
-    .map(key => Symbol[key])
+    .map(key => {
+      try {
+        return Symbol[key]
+      } catch (e) {
+        return null;
+      }
+    })
     .filter(value => typeof value === 'symbol')
 )
 


### PR DESCRIPTION
We use observable and observer from  your library. After this fix library started working on IE11.