### PR TITLE
Introduce a global reaction callback

### DIFF
--- a/src/internals.js
+++ b/src/internals.js
@@ -1,2 +1,3 @@
 export const proxyToRaw = new WeakMap()
 export const rawToProxy = new WeakMap()
+export const updateFnDefiniton = new WeakMap();

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,25 +1,30 @@
-import { proxyToRaw, rawToProxy } from './internals'
+import { proxyToRaw, rawToProxy, updateFnDefiniton } from './internals'
 import { storeObservable } from './store'
 import * as builtIns from './builtIns'
 import baseHandlers from './handlers'
 
-export function observable (obj = {}) {
+export function observable (obj = {}, updateFn = undefined) {
   // if it is already an observable or it should not be wrapped, return it
   if (proxyToRaw.has(obj) || !builtIns.shouldInstrument(obj)) {
     return obj
   }
+
   // if it already has a cached observable wrapper, return it
   // otherwise create a new observable
-  return rawToProxy.get(obj) || createObservable(obj)
+  return rawToProxy.get(obj) || createObservable(obj, updateFn);
 }
 
-function createObservable (obj) {
+function createObservable (obj, updateFn) {
   // if it is a complex built-in object or a normal object, wrap it
   const handlers = builtIns.getHandlers(obj) || baseHandlers
   const observable = new Proxy(obj, handlers)
   // save these to switch between the raw object and the wrapped object with ease later
   rawToProxy.set(obj, observable)
   proxyToRaw.set(observable, obj)
+
+  // set the global reaction for this store
+  updateFnDefiniton.set(observable, updateFn);
+
   // init basic data structures to save and cleanup later (observable.prop -> reaction) connections
   storeObservable(obj)
   return observable

--- a/tests/observe.test.js
+++ b/tests/observe.test.js
@@ -545,4 +545,54 @@ describe('options', () => {
     observed.obj = document
     expect(dummy).to.equal(9)
   })
+
+  it('should do a global reaction.', () => {
+    let counter = 0
+    let obs = observable({}, () => { counter++ });
+
+    expect(counter).to.equal(0);
+    obs.lol = 'hi';
+    expect(counter).to.equal(1);
+    obs.lol2 = { wow: 'cool', me: { you: {} } };
+    expect(counter).to.equal(2);
+    obs.lol2.me.you.test = 'else';
+    expect(counter).to.equal(3);
+  });
+
+  it('should do a global reaction on a set', () => {
+    let counter = 0
+    let obs = observable({ x: new Set() }, () => { counter++ });
+
+    expect(counter).to.equal(0);
+    obs.x.add('hi there')
+    expect(counter).to.equal(1);
+  });
+
+  it('should only call the right global reaction', () => {
+    let counterA = 0;
+    let counterB = 0;
+
+    let obsA = observable({}, () => { counterA++ });
+    let obsB = observable({}, () => { counterB++ });
+
+    expect(counterA).to.equal(0);
+    expect(counterB).to.equal(0);
+
+    obsA.wow = 'hi';
+
+    expect(counterA).to.equal(1);
+    expect(counterB).to.equal(0);
+  });
+
+  it('should do a global reaction on delete.', () => {
+    let counter = 0
+    let obs = observable({}, () => { counter++ });
+
+    expect(counter).to.equal(0);
+    obs.lol = 'hi';
+    expect(counter).to.equal(1);
+    delete obs.lol;
+    expect(counter).to.equal(2);
+  });
+
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@nx-js/observer-util' {
-  function observable<Observable extends object>(obj?: Observable): Observable
+  function observable<Observable extends object>(obj?: Observable, onChange: () => void): Observable
   function isObservable(obj: object): boolean
   function raw<Observable extends object>(obj: Observable): Observable
 


### PR DESCRIPTION
For performance optimization.

In our app, datawisp.io we use observer-uitl via react-easy-state.

We have one big store where we store all of the sheets of a user, and if the user changes something, we automatically sync those changes to `localStorage`, and, for some of them, to a server.

However, we need to get notified somehow if anyone modifies that store. To do this, we need to have one global reaction on *everything*, but that's complicated, because for that to happen, every single nested needs to be touched. So, as a hack, we had introduced this pattern:

```js=
var obj = observable({});
observe(() => {
  // touch everything
  JSON.stringify(obj);

  window.setTimeout(diffEverything, 1000);
});
```

however, as you can see, that can become fairly inefficient once the object gets big. Serializing 500kb of json every time something gets touched is not all that performant, as it turns out.

So, we've changed the interface a little, so you can provide a global reaction to `observable`, that gets called every time something is changed within an object.

```js=

var obj = observable({}, () => { console.log('object changed!', JSON.stringify(obj)) );

obj.x = 'hello!' // object changed '{ "x": "hello!" }'
```

Known limitations:

- Adding a store to a store with a reaction will not work right. There's a warning for this.
- No batching of any kind
- You can very easily set up a circular dependency in a global reaction that prevents an object from being GC'd

I'm not sure if this *should* be merged into the main thing. We found it very useful, and it made our app nice and snappy 
again. That said, the limitations are big, and solving esp. the first one.

So, while it fits our use-case *a lot*, there are a couple of foot-guns that users should be aware of.