### PR TITLE
Better types with branding

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,17 @@
 declare module '@nx-js/observer-util' {
-  function observable<Observable extends object>(obj?: Observable): Observable
+  class ObservableBrand {
+        protected __OBSERVABLE_NOMINAL_BRAND: never;
+  }
+
+  type Observed<T> = T & ObservableBrand;
+
+  type MonoObserved<T> = T extends Observed<infer U>
+    ? MonoObserved<U>
+    : T;
+
+  function observable<Observable extends object>(obj?: Observable): Observed<MonoObserved<Observable>>
   function isObservable(obj: object): boolean
-  function raw<Observable extends object>(obj: Observable): Observable
+  function raw<Observable extends object>(obj: Observable): Observable extends Observed<infer T> ? MonoObserved<T> : Observable;
 
   interface Scheduler {
     add: Function


### PR DESCRIPTION
This change adds a protected brand to what is returned by observable, and removes it from raw. This allows tracking of what is observable by the type system.

The existing code used proxies, which are transparent: there is no way to distinguish a proxy from a non-proxy. This leads to awkward code that takes a parameter, observes that parameter, and really really hopes that parameter was observable. The alternative is to do a runtime check for obervable-ness, which has both performance and legibility implications.

I've used this a little so far and its worked well, but it may have issues with very complex types I haven't seen yet. It also does impose a requirement that observed types cannot have a property called __OBSERVABLE_NOMINAL_BRAND. This seemed an acceptable trade-off.

Future work could be to turn isObservable into a typeguard from T to Observable<T>.